### PR TITLE
Fixed issue with using the Screenshot service on a Mac.

### DIFF
--- a/src/main/java/org/libimobiledevice/ios/driver/binding/raw/ImobiledeviceSdkLibrary.java
+++ b/src/main/java/org/libimobiledevice/ios/driver/binding/raw/ImobiledeviceSdkLibrary.java
@@ -21,7 +21,8 @@ import java.util.List;
  * For help, please visit <a href="http://nativelibs4java.googlecode.com/">NativeLibs4Java</a> , <a href="http://rococoa.dev.java.net/">Rococoa</a>, or <a href="http://jna.dev.java.net/">JNA</a>.
  */
 public class ImobiledeviceSdkLibrary implements Library {
-	public static final String JNA_LIBRARY_NAME = "imobiledevice-sdk";
+    private static final boolean initialized = JNAInit.init();
+    public static final String JNA_LIBRARY_NAME = "imobiledevice-sdk";
 	public static final NativeLibrary JNA_NATIVE_LIB = NativeLibrary.getInstance(ImobiledeviceSdkLibrary.JNA_LIBRARY_NAME);
 	static {
 		Native.register(ImobiledeviceSdkLibrary.class, ImobiledeviceSdkLibrary.JNA_NATIVE_LIB);

--- a/src/main/java/org/libimobiledevice/ios/driver/binding/raw/JNAInit.java
+++ b/src/main/java/org/libimobiledevice/ios/driver/binding/raw/JNAInit.java
@@ -79,7 +79,6 @@ public class JNAInit {
     copy("darwin/idevicedebug", dst);
     dst.setExecutable(true);
 
-    ImobiledeviceSdkLibrary.sdk_idevice_event_unsubscribe();
     initialize = true;
     return true;
   }


### PR DESCRIPTION
Prior to this fix getting screenshots from devices would result in the following exception:

Exception in thread "main" java.lang.UnsatisfiedLinkError: Unable to load library 'imobiledevice-sdk': dlopen(libimobiledevice-sdk.dylib, 9): image not found
    at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:169)
    at com.sun.jna.NativeLibrary.getInstance(NativeLibrary.java:242)
    at com.sun.jna.NativeLibrary.getInstance(NativeLibrary.java:205)
    at org.libimobiledevice.ios.driver.binding.raw.ImobiledeviceSdkLibrary.<clinit>(ImobiledeviceSdkLibrary.java:25)
    at org.libimobiledevice.ios.driver.binding.services.IOSDevice.<init>(IOSDevice.java:44)
    at org.libimobiledevice.ios.driver.binding.services.DeviceService.get(DeviceService.java:37)
    at IosDriverTest.runTest(IosDriverTest.java:66)
    at IosDriverTest.main(IosDriverTest.java:23)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:120)
